### PR TITLE
Added Feature for API key rotating from File with -ak arguments

### DIFF
--- a/apishodan/api.go
+++ b/apishodan/api.go
@@ -42,31 +42,35 @@ func New(key string) *API {
 }
 
 func (s *API) InfoAccount() (*JsonData, error) {
-	res, err := http.Get(fmt.Sprintf("%s/api-info?key=%s", URL, s.apiKey))
-	if err != nil {
-		return nil, fmt.Errorf("failed to make request ( Info Account Shodan ): %v", err)
-	}
-	defer res.Body.Close()
+    res, err := http.Get(fmt.Sprintf("%s/api-info?key=%s", URL, s.apiKey))
+    if err != nil {
+        return nil, fmt.Errorf("failed to make request ( Info Account Shodan ): %v", err)
+    }
+    defer res.Body.Close()
 
-	if res.StatusCode == http.StatusUnauthorized {
-		return nil, fmt.Errorf("authorization error: invalid Shodan API key (HTTP 401)")
-	}
+    if res.StatusCode == http.StatusUnauthorized {
+        return nil, fmt.Errorf("invalid API key (HTTP 401)")
+    }
 
-	if res.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("unexpected status code: %d", res.StatusCode)
-	}
+    if res.StatusCode == http.StatusForbidden {
+        return nil, fmt.Errorf("API key has hit its limit (HTTP 403)")
+    }
 
-	body, err := io.ReadAll(res.Body)
-	if err != nil {
-		return nil, fmt.Errorf("failed to read response body: %v", err)
-	}
+    if res.StatusCode != http.StatusOK {
+        return nil, fmt.Errorf("unexpected status code: %d", res.StatusCode)
+    }
 
-	var ret JsonData
-	if err := json.Unmarshal(body, &ret); err != nil {
-		return nil, fmt.Errorf("failed to decode JSON response: %v", err)
-	}
+    body, err := io.ReadAll(res.Body)
+    if err != nil {
+        return nil, fmt.Errorf("failed to read response body: %v", err)
+    }
 
-	return &ret, nil
+    var ret JsonData
+    if err := json.Unmarshal(body, &ret); err != nil {
+        return nil, fmt.Errorf("failed to decode JSON response: %v", err)
+    }
+
+    return &ret, nil
 }
 
 func (s *API) GetSubdomain(domain string) (*JsonSubDomain, error) {

--- a/main.go
+++ b/main.go
@@ -14,8 +14,10 @@ import (
 const Author = "inc0gbyt3"
 
 func main() {
+    // Define and parse flags
     domain := flag.String("d", "", "> Domain to find subdomains")
-    shodanKey := flag.String("s", "", "> Shodan api key")
+    shodanKey := flag.String("s", "", "> Shodan API key")
+    apiKeyFile := flag.String("ak", "", "> API key file (1 per line)")
     verbose := flag.Bool("v", false, "> Show all output")
     fileName := flag.String("o", "", "> Save domains into a file")
     inputFile := flag.String("f", "", "> File containing domains to find subdomains")
@@ -23,19 +25,28 @@ func main() {
     flag.Parse()
 
     if *domain == "" && *inputFile == "" {
-        fmt.Printf("[*] Usage: %s -d target.com -s shodanKey [-f input_file]\n", os.Args[0])
+        fmt.Printf("[*] Usage: %s -d target.com -s shodanKey  [-f input_file]\n", os.Args[0])
         fmt.Printf("[*] Author: %s\n", Author)
         os.Exit(1)
     }
 
-    apiKey := apishodan.New(*shodanKey)
+    // Load API keys
+    var apiKeys []string
+    if *apiKeyFile != "" {
+        var err error
+        apiKeys, err = readAPIKeysFromFile(*apiKeyFile)
+        if err != nil {
+            log.Fatalf("Failed to read API keys from file: %v", err)
+        }
+    } else if *shodanKey != "" {
+        apiKeys = append(apiKeys, *shodanKey)
+    }
 
+    // Load domains
     var domains []string
-
     if *domain != "" {
         domains = append(domains, *domain)
     }
-
     if *inputFile != "" {
         fileDomains, err := readDomainsFromFile(*inputFile)
         if err != nil {
@@ -44,8 +55,41 @@ func main() {
         domains = append(domains, fileDomains...)
     }
 
+    // Track API key status
+    workingKeys, invalidKeys, limitExceededKeys := 0, 0, 0
+
+    fmt.Println("")
+
+    for _, apiKeyStr := range apiKeys {
+        apiKey := apishodan.New(apiKeyStr)
+        info, err := apiKey.InfoAccount()
+        if err != nil {
+            switch err.Error() {
+            case "invalid API key (HTTP 401)":
+                invalidKeys++
+                fmt.Printf("API Key %s: Invalid API key.\n", apiKeyStr)
+            case "API key has hit its limit (HTTP 403)":
+                limitExceededKeys++
+                fmt.Printf("API Key %s: API key has hit its limit.\n", apiKeyStr)
+            default:
+                fmt.Printf("API Key %s: Error with Shodan API key: %v\n", apiKeyStr, err)
+            }
+        } else {
+            workingKeys++
+            fmt.Printf("[*] API Key %s: Working API Key.\n", apiKeyStr)
+            // Display account info for verbose output
+            if *verbose {
+                fmt.Printf("\n[*] Credits: %d\n[*] Scan Credits: %d\n\n", info.QueryCredits, info.ScanCredits)
+            }
+        }
+    }
+
+    fmt.Printf("\n[*] Total API Keys: %d\n[*] Working API Keys: %d\n[*] Invalid API Keys: %d\n[*] API Keys hit their limit: %d\n\n",
+        len(apiKeys), workingKeys, invalidKeys, limitExceededKeys)
+
+    // Retrieve and display subdomains
     for _, domainSearch := range domains {
-        subdomain, err := apiKey.GetSubdomain(domainSearch)
+        subdomain, err := apishodan.New(apiKeys[0]).GetSubdomain(domainSearch) // Replace with proper key handling if needed
         if err != nil {
             fmt.Printf("Error fetching subdomains for domain %s: %v\n", domainSearch, err)
             continue
@@ -56,63 +100,45 @@ func main() {
             continue
         }
 
-        if *verbose {
-            info, err := apiKey.InfoAccount()
+        if *jsonFlag {
+            jsonData, err := json.MarshalIndent(subdomain.SubDomains, "", "  ")
             if err != nil {
-                fmt.Printf("Error fetching account info: %v\n", err)
-                continue
+                log.Fatal("Error marshaling JSON:", err)
             }
-            fmt.Printf("[*] Credits: %d\nScan Credits: %d\n\n", info.QueryCredits, info.ScanCredits)
-
-            for _, v := range subdomain.Data {
-                d := v.SubD + subdomain.Domain
-                fmt.Printf("[*] Domain: %s\nIP/DNS: %s\nLast Scan made by Shodan: %s\n", d, v.Value, v.LastSeen)
+            if *fileName != "" {
+                writeFile(*fileName, string(jsonData))
+            } else {
+                fmt.Println(string(jsonData))
             }
         } else {
-            if *jsonFlag {
-                jsonData, err := json.MarshalIndent(subdomain.SubDomains, "", "  ")
-                if err != nil {
-                    log.Fatal("Error marshaling JSON:", err)
-                }
+            for _, v := range subdomain.SubDomains {
+                formattedSubdomain := fmt.Sprintf("%s.%s", v, domainSearch)
+                fmt.Println(formattedSubdomain)
                 if *fileName != "" {
-                    f, err := os.OpenFile(*fileName, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
-                    if err != nil {
-                        log.Fatal(err)
-                    }
-                    _, err = f.Write(jsonData)
-                    if err != nil {
-                        log.Fatal(err)
-                    }
-                    _, err = f.WriteString("\n")
-                    if err != nil {
-                        log.Fatal(err)
-                    }
-                    f.Close()
-                    fmt.Println("[*] DONE writing JSON to file:", *fileName)
-                } else {
-                    fmt.Println(string(jsonData))
-                }
-            } else {
-                for _, v := range subdomain.SubDomains {
-                    if *fileName != "" {
-                        f, err := os.OpenFile(*fileName, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
-                        if err != nil {
-                            log.Fatal(err)
-                        }
-                        _, err = f.WriteString(v + "\n")
-                        if err != nil {
-                            log.Fatal(err)
-                        }
-                        f.Close()
-                        fmt.Println("[*] DONE writing to file:", *fileName)
-                    }
-                    fmt.Printf("%s.%s\n", v, domainSearch)
+                    writeFile(*fileName, formattedSubdomain+"\n")
                 }
             }
         }
     }
 }
 
+// Reads API keys from a file
+func readAPIKeysFromFile(filename string) ([]string, error) {
+    file, err := os.Open(filename)
+    if err != nil {
+        return nil, err
+    }
+    defer file.Close()
+
+    var apiKeys []string
+    scanner := bufio.NewScanner(file)
+    for scanner.Scan() {
+        apiKeys = append(apiKeys, scanner.Text())
+    }
+    return apiKeys, scanner.Err()
+}
+
+// Reads domains from a file
 func readDomainsFromFile(filename string) ([]string, error) {
     file, err := os.Open(filename)
     if err != nil {
@@ -125,9 +151,18 @@ func readDomainsFromFile(filename string) ([]string, error) {
     for scanner.Scan() {
         domains = append(domains, scanner.Text())
     }
-    if err := scanner.Err(); err != nil {
-        return nil, err
-    }
+    return domains, scanner.Err()
+}
 
-    return domains, nil
+// Writes to a file with optional appending
+func writeFile(filename, data string) {
+    f, err := os.OpenFile(filename, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+    if err != nil {
+        log.Fatal(err)
+    }
+    defer f.Close()
+    if _, err := f.WriteString(data); err != nil {
+        log.Fatal(err)
+    }
+    fmt.Printf("[*] Written to file: %s\n", filename)
 }


### PR DESCRIPTION
#14  Upon roaming with this issue , I have updated the code to work like this i.e. API key rotation .

### I have kept two api key in `api.txt`  file . First one was invalid and second working.



**Major Change's Done:**

1. Added the **-ak** flag to accept a file containing multiple API keys (one per line).
2. Output for total keys processed, including counts for working, invalid, and limit-exceeded keys.
3. Added Space for Output format.


### After:

![after](https://github.com/user-attachments/assets/61bb64a2-d276-45d2-8816-31ce951e9da0)

